### PR TITLE
move items up treasure island

### DIFF
--- a/frontend/public/collection.css
+++ b/frontend/public/collection.css
@@ -4,7 +4,7 @@
   background-size: cover;
   background-repeat: no-repeat;
   background-attachment: fixed;
-  height: 1200px;
+  min-height: 1200px;
 }
 
 .collection-header {

--- a/frontend/public/treasureisland.css
+++ b/frontend/public/treasureisland.css
@@ -53,7 +53,7 @@
 
 
 .chest {
-  margin-top: 500px;
+  margin-top: 240px;
   margin-left: 140px;
   height: 450px;
   border-radius: 20%;
@@ -89,7 +89,7 @@
   width: 500px;
   height: 600px;
   margin-left: 80px;
-  margin-top: 200px;
+  margin-top: 50px;
   margin-right: 35px;
 }
 


### PR DESCRIPTION
The chest and options menu were a bit low on the Treasure Island page. I lowered the margins so you do not have to scroll down as far.